### PR TITLE
Make customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Update contributors in `package.json` - all developers who commited to the repos
     file: 'package.json',
     commit: true,
     commitMessage: 'Update contributors',
-    as: 'contributors'
+    as: 'contributors',
+    filter: function(contributors) {
+      // assuming the top commiter is the author, ignore him as a contributor
+      return contributors.slice(1);
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Update contributors in `package.json` - all developers who commited to the repos
   options: {
     file: 'package.json',
     commit: true,
-    commitMessage: 'Update contributors'
+    commitMessage: 'Update contributors',
+    as: 'contributors'
   }
 }
 ```

--- a/tasks/npm.js
+++ b/tasks/npm.js
@@ -101,10 +101,19 @@ module.exports = function(grunt) {
       var contributors = stdout.toString().split('\n').filter(function(line) {
         return line.length;
       }).map(function(line) {
-        return line.replace(/^[\W\d]+/, '');
+        var lineNumberMatcher = /^[\W\d]+/;
+        return {
+          name: line.replace(lineNumberMatcher, ''),
+          commitCount: parseInt(line.match(lineNumberMatcher)[0], 10)
+        };
       });
 
       pkg[opts.as] = opts.filter(contributors);
+      if (_.isArray(pkg[opts.as])) {
+        pkg[opts.as] = pkg[opts.as].map(function(contributor) {
+          return contributor.name;
+        });
+      }
 
       grunt.file.write(opts.file, JSON.stringify(pkg, null, '  ') + '\n');
 

--- a/tasks/npm.js
+++ b/tasks/npm.js
@@ -83,13 +83,14 @@ module.exports = function(grunt) {
     var opts = this.options({
       file: 'package.json',
       commit: true,
-      commitMessage: 'Update contributors'
+      commitMessage: 'Update contributors',
+      as: 'contributors'
     });
 
     exec('git log --pretty=short | git shortlog -nse', function(err, stdout) {
       var pkg = grunt.file.readJSON(opts.file);
 
-      pkg.contributors = stdout.toString().split('\n').slice(1, -1).map(function(line) {
+      pkg[opts.as] = stdout.toString().split('\n').slice(1, -1).map(function(line) {
         return line.replace(/^[\W\d]+/, '');
       });
 

--- a/tasks/npm.js
+++ b/tasks/npm.js
@@ -79,7 +79,7 @@ module.exports = function(grunt) {
   /**
    * Generate contributors, all developers who contributed, sorted by number of commits.
    */
-  grunt.registerTask('npm-contributors', 'Update contributors in package.json', function() {
+  grunt.registerMultiTask('npm-contributors', 'Update contributors in package.json', function() {
     var done = this.async();
     var opts = this.options({
       file: 'package.json',


### PR DESCRIPTION
including / follow up PR #4 

I'd like to spread contributors into `author`, `maintainers` and `contributors` fields.

With this changes i'm able to add multiple tasks filtering multiple parts of the contributor list into different keys in my package.json

Example:

``` js
'npm-contributors': {
  bower: {
    options: {
      file: 'bower.json',
      commitMessage: 'update bower authors',
      filter: false,
      as: 'authors'
    }
  },
  author: {
    options: {
      file: 'package.json',
      commit: false,
      filter: function(contributors) {
        return contributors[0].name;
      },
      as: 'author'
    }
  },
  maintainers: {
    options: {
      file: 'package.json',
      commit: false,
      filter: function(contributors) {
        return contributors.slice(1).filter(function(contributor) {
          return contributor.commitCount >= 10;
        });
      },
      as: 'maintainers'
    }
  },
  contributors: {
    options: {
      file: 'package.json',
      commitMessage: 'Update contributors',
      filter: function(contributors) {
        return contributors.slice(1).filter(function(contributor) {
          return contributor.commitCount < 10;
        });
      }
    }
  }
}
```
